### PR TITLE
(#14) fixed error in nuspec

### DIFF
--- a/nuspec/nuget/Cake.Discord.nuspec
+++ b/nuspec/nuget/Cake.Discord.nuspec
@@ -16,9 +16,9 @@
     <tags>Cake, Script, Build, Discord</tags>
   </metadata>
   <files>
-    <file src="net46\Cake.Discord.dll" target="lib/netstandard2.0" />
-    <file src="net46\Cake.Discord.pdb" target="lib/netstandard2.0" />
-    <file src="net46\Cake.Discord.xml" target="lib/netstandard2.0" />
+    <file src="net46\Cake.Discord.dll" target="lib/net46" />
+    <file src="net46\Cake.Discord.pdb" target="lib/net46" />
+    <file src="net46\Cake.Discord.xml" target="lib/net46" />
     <file src="netstandard2.0\Cake.Discord.dll" target="lib/netstandard2.0" />
     <file src="netstandard2.0\Cake.Discord.pdb" target="lib/netstandard2.0" />
     <file src="netstandard2.0\Cake.Discord.xml" target="lib/netstandard2.0" />


### PR DESCRIPTION
## Description

Both, net46 libs and netstandard2.0 libs were set to be
included in the netstandard2.0 folder of the nupkg.

## Related Issue
#14 

## Motivation and Context
#14 

## How Has This Been Tested?
Manual test: Build no longer fails.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Changes to the build process.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
