### PR TITLE
Add NuGet.Config restricting feeds to nuget.org

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
## Summary

Cake.Recipe 4.0.0 hardcodes `https://www.myget.org/F/cake-contrib/api/v3/index.json` as a fallback NuGet source whenever the addin lacks a `NuGet.Config` (see `Cake.Recipe/Source/Cake.Recipe/Content/parameters.cake:361`). MyGet is currently flaky (HTTP 500), causing PR CI to fail intermittently — see Cake.FileHelpers / Cake.Twitter recent failures.

Shipping a `NuGet.Config` at the repo root takes the `if (FileExists(NugetConfig))` branch in the recipe and skips the broken MyGet fallback entirely.

## Test plan

- [ ] CI build (windows-2025) passes
- [ ] CI build (ubuntu-24.04) passes
- [ ] CodeQL passes